### PR TITLE
Work around an audio problem on iOS Safari

### DIFF
--- a/atsumarize/sandbox.js
+++ b/atsumarize/sandbox.js
@@ -32,7 +32,20 @@ window.addEventListener("load", function() {
 		var pf = new pdiBrowser.Platform({
 			amflow: amflowClient,
 			containerView: document.getElementById("container"),
-			audioPlugins: [pdiBrowser.HTMLAudioPlugin],
+			audioPlugins: [pdiBrowser.WebAudioPlugin],
+			disablePreventDefault: true
+		});
+
+		// iOS Safari の音声用ワークアラウンド
+		var audioTouchInitialized = false;
+		document.addEventListener("touchstart", function () {
+			if (audioTouchInitialized) return;
+			audioTouchInitialized = true;
+			var g = require("@akashic/akashic-engine");
+			var p = new pdiBrowser.WebAudioPlugin();
+			var dummyAudioSystem = new g.AudioSystem("dummy", { _audioSystemManager: new g.AudioSystemManager({}) });
+			var ctx = p.createPlayer(dummyAudioSystem)._audioContext; // ダミーのコードでとにかくAudioContextを抜いてくる
+			ctx.createBufferSource().start(0); // 本題
 		});
 
 		pf.loadGameConfiguration = function(url, callback) {


### PR DESCRIPTION
iOS Safari 上ではユーザインタラクションなしには音声が再生できません。
エンジン側ではなく利用側コードで暫定的に問題を回避します。
